### PR TITLE
calendar-ui-brushup

### DIFF
--- a/src/app/Http/Controllers/CalendarController.php
+++ b/src/app/Http/Controllers/CalendarController.php
@@ -2,47 +2,95 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Http\Requests\CalendarRequest;
 use App\Models\Calendar;
 use App\Models\User;
 use App\Notifications\CalendarEventCreated;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use App\Http\Requests\CalendarRequest;
 
 class CalendarController extends Controller
 {
-    public function index()
+    /**
+     * カレンダートップ
+     */
+    public function index(Request $request)
     {
-        $familyId = auth()->user()->family_id;
+        $user      = $request->user();
+        $familyId  = $user->family_id;
 
-        $events = Calendar::where('family_id', $familyId) // ✅ family 基準に変更
-            ->orderBy('event_date')
-            ->orderBy('event_time')
+        // 選択日（/calendar?date=YYYY-MM-DD）
+        $selected = $request->query('date');
+
+        // 表示月（/calendar?month=YYYY-MM-01 など）未指定は当月
+        $monthStr     = $request->query('month');
+        $currentMonth = $monthStr ? Carbon::parse($monthStr) : Carbon::today();
+
+        $monthStart = $currentMonth->copy()->startOfMonth()->toDateString();
+        $monthEnd   = $currentMonth->copy()->endOfMonth()->toDateString();
+
+        // 今月の予定（リスト描画用）
+        $events = Calendar::where('family_id', $familyId)
+            ->whereBetween('event_date', [$monthStart, $monthEnd])
+            ->orderBy('event_date')->orderBy('event_time')
             ->get();
 
-        return view('calendar.index', compact('events'));
+        $eventsByDate = $events->groupBy('event_date');
+
+        // 選択日の予定
+        $dayEvents = collect();
+        if ($selected) {
+            $dayEvents = Calendar::where('family_id', $familyId)
+                ->whereDate('event_date', $selected)
+                ->orderBy('event_time')
+                ->get();
+        }
+
+        // FullCalendar 用（必ず YYYY-MM-DD に整形してから THH:MM を付ける）
+        $fcEvents = Calendar::where('family_id', $familyId)
+            ->orderBy('event_date')->orderBy('event_time')
+            ->get()
+            ->map(function ($e) {
+                // event_date は casts('date') なので Carbon → YYYY-MM-DD 化
+                $date = $e->event_date instanceof Carbon
+                    ? $e->event_date->toDateString()
+                    : (string) $e->event_date;
+
+                $time = $e->event_time_hi; // "HH:MM" または null（Modelアクセサ）
+
+                return [
+                    'id'          => $e->id,
+                    'title'       => $e->title,
+                    'start'       => $time ? "{$date}T{$time}" : $date,
+                    'allDay'      => $time ? false : true,
+                    'description' => $e->description,
+                ];
+            })->values();
+
+        return view('calendar.index', compact('eventsByDate', 'dayEvents', 'selected', 'fcEvents'));
     }
 
+    /**
+     * 作成（秒なしで保存）
+     */
     public function store(CalendarRequest $request)
     {
+        $auth = $request->user();
+
         DB::beginTransaction();
         try {
-            $auth = auth()->user();
+            $data = $request->validated();
+            $data['family_id']  = $auth->family_id;
+            $data['user_id']    = $auth->id;
+            $data['event_time'] = $data['event_time'] ?: null; // "HH:MM" or null
 
-            $calendar = Calendar::create([
-                'family_id'   => $auth->family_id,          // ✅ これが重要
-                'pair_id'     => $this->pair->id ?? null,   // 互換のため残してOK
-                'user_id'     => $auth->id,
-                'title'       => $request->title,
-                'event_date'  => $request->event_date,
-                'event_time'  => $request->event_time,
-                'description' => $request->description,
-            ]);
+            $calendar = Calendar::create($data);
 
-            // 通知（既存ロジックのまま）
+            // 家族内の他メンバーへ通知（任意）
             $partner = User::where('family_id', $auth->family_id)
-                        ->where('id', '!=', $auth->id)
-                        ->first();
+                ->where('id', '!=', $auth->id)
+                ->first();
 
             if ($partner) {
                 $calendar->user = $auth;
@@ -51,46 +99,62 @@ class CalendarController extends Controller
 
             DB::commit();
             return redirect()->route('calendar.index')->with('success', '予定を追加しました！');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             DB::rollBack();
+            report($e);
             return back()->with('error', '予定の登録中にエラーが発生しました。')->withInput();
         }
     }
 
-    public function edit($id)
+    /**
+     * 編集
+     */
+    public function edit($id, Request $request)
     {
-        $event = Calendar::findOrFail($id);
-
-        if ($event->pair_id !== $this->pair?->id) {
-            abort(403, '許可されていません');
-        }
+        $auth  = $request->user();
+        $event = Calendar::where('id', $id)
+            ->where('family_id', $auth->family_id)
+            ->firstOrFail();
 
         return view('calendar.edit', compact('event'));
     }
 
+    /**
+     * 更新（秒なしで保存）
+     */
     public function update(CalendarRequest $request, $id)
     {
-        $event = Calendar::findOrFail($id);
-
-        if ($event->pair_id !== $this->pair?->id) {
-            abort(403, '許可されていません');
-        }
+        $auth  = $request->user();
+        $event = Calendar::where('id', $id)
+            ->where('family_id', $auth->family_id)
+            ->firstOrFail();
 
         DB::beginTransaction();
         try {
-            $event->update($request->all());
+            $data = $request->validated();
+            $data['event_time'] = $data['event_time'] ?: null;
+
+            $event->update($data);
 
             DB::commit();
             return redirect()->route('calendar.index')->with('success', '予定を更新しました！');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             DB::rollBack();
+            report($e);
             return back()->with('error', '予定の更新に失敗しました。')->withInput();
         }
     }
 
-    public function destroy($id)
+    /**
+     * 削除
+     */
+    public function destroy($id, Request $request)
     {
-        $event = Calendar::findOrFail($id);
+        $auth  = $request->user();
+        $event = Calendar::where('id', $id)
+            ->where('family_id', $auth->family_id)
+            ->firstOrFail();
+
         $event->delete();
 
         return redirect()->route('calendar.index')->with('success', '予定を削除しました！');

--- a/src/app/Models/Calendar.php
+++ b/src/app/Models/Calendar.php
@@ -2,51 +2,45 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Carbon\Carbon;
 
 class Calendar extends Model
 {
-    use HasFactory;
-
     protected $table = 'calendars';
 
-    // ✅ family_id を追加（これが無いと保存されない）
     protected $fillable = [
         'family_id',
-        'pair_id',     // ※将来廃止予定なら残してOK
+        'pair_id',      // 互換で残すならOK（未使用なら削除可）
         'user_id',
         'title',
         'event_date',
-        'event_time',
+        'event_time',   // "HH:MM" or null
         'description',
     ];
 
-    // ✅ event_time は time型なので string で扱うのが安全
     protected $casts = [
-        'event_date' => 'date',
-        'event_time' => 'string',
+        'event_date' => 'date', // Carbon にキャスト
     ];
 
-    public function pair()
+    /**
+     * 表示用アクセサ：常に "HH:MM" を返す（秒は切る）
+     */
+    public function getEventTimeHiAttribute(): ?string
     {
-        return $this->belongsTo(Pair::class);
-    }
-    public function user()
-    {
-        return $this->belongsTo(User::class);
-    }
-
-    // 便利アクセサ（“HH:mm”）
-    public function getEventTimeHmAttribute(): ?string
-    {
-        if (!$this->event_time) {
+        $t = $this->attributes['event_time'] ?? null;
+        if (!$t) {
             return null;
         }
+
+        $s = (string)$t;
+        if (preg_match('/^\d{2}:\d{2}/', $s)) {
+            return substr($s, 0, 5); // "HH:MM(:SS)" → "HH:MM"
+        }
         try {
-            return \Carbon\Carbon::createFromFormat('H:i:s', $this->event_time)->format('H:i');
+            return Carbon::parse($s)->format('H:i');
         } catch (\Throwable $e) {
-            return (string)$this->event_time; // 既存データが H:i の場合もそのまま
+            return substr($s, 0, 5);
         }
     }
 }

--- a/src/public/css/custom.css
+++ b/src/public/css/custom.css
@@ -1,28 +1,36 @@
-@media (max-width: 768px) {
-    .pair-info {
-        font-size: 12px !important;
-        white-space: nowrap;
-    }
+/* ============================================================================
+  Design tokens
+============================================================================ */
+:root {
+    /* brand */
+    --brand-green: #198754;
+    --brand-green-ink: #0f5132;
+    --brand-blue: #0d6efd;
+
+    /* neutrals */
+    --ink-muted: #6c757d;
+    --border: #eee;
+    --ring: rgba(0, 0, 0, 0.1);
+    --shadow: 0 10px 18px rgba(0, 0, 0, 0.18);
+
+    /* surfaces */
+    --card-bg: #fff;
+    --chip-bg: #e7f3ee;
+
+    /* radius / spacing */
+    --radius-xl: 15px;
+    --radius-full: 999px;
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
 }
 
+/* ============================================================================
+  Utilities (小さめの共通ユーティリティ)
+============================================================================ */
 .text-left {
     text-align: left !important;
-}
-
-.category-btn {
-    flex: 1; /* ボタンの幅を均等にする */
-    min-width: 18%; /* 5つのボタンが1行に収まるよう調整 */
-    max-width: 20%;
-    font-size: 12px; /* 文字を小さくする */
-    padding: 6px 4px; /* ボタンの内側余白を調整 */
-    text-align: center;
-    white-space: nowrap; /* 文字の改行を防ぐ */
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.d-flex {
-    gap: 4px; /* ボタン間の隙間を調整 */
 }
 
 .auto-font-size {
@@ -30,21 +38,38 @@
     white-space: nowrap;
 }
 
-.menu-label {
-    font-size: 0.85rem; /* 少し小さく */
-    max-width: 100%;
-    overflow: hidden;
+/* gap ユーティリティ（広域 .d-flex への上書きは避ける） */
+.gap-1 {
+    gap: var(--space-1);
+}
+.gap-2 {
+    gap: var(--space-2);
 }
 
+/* 小さめラベル */
+.menu-label {
+    font-size: 0.85rem;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* ============================================================================
+  Header / Dropdowns
+============================================================================ */
 #notificationDropdown + .dropdown-menu {
-    left: auto !important;
     right: 0 !important;
+    left: auto !important;
     top: 100% !important;
 }
 
+/* ============================================================================
+  Cards / Avatars
+============================================================================ */
 .card {
-    border-radius: 15px;
-    border: 1px solid #eee;
+    border-radius: var(--radius-xl);
+    border: 1px solid var(--border);
+    background: var(--card-bg);
 }
 
 .rounded-circle {
@@ -52,20 +77,18 @@
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
+/* ============================================================================
+  Login page
+  - 重複・競合を整理（background は一度だけ指定）
+============================================================================ */
 .login-page {
-    background-image: url("images/main-visual.jpg");
-    background-size: cover;
-    background-position: center;
-    position: relative;
+    min-height: 100vh;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: flex-start;
     padding-left: 5%;
-
-    display: flex;
-    flex-wrap: wrap;
-    min-height: 100vh;
-    background-color: #f9f9f9;
+    background: url("images/main-visual.jpg") center/cover no-repeat, #f9f9f9;
 }
 
 .left-textbox {
@@ -85,7 +108,7 @@
 }
 
 .login-box {
-    background-color: #ffffff;
+    background: #fff;
     padding: 2rem;
     border-radius: 1rem;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
@@ -98,18 +121,165 @@
     height: 60px;
     border-radius: 50%;
     object-fit: cover;
-    background-color: #f1f3f5;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 28p;
+    background: #f1f3f5;
+    display: grid;
+    place-items: center;
+    font-size: 28px; /* typo: 28p → 28px */
 }
 
+/* ============================================================================
+  Feature cards
+============================================================================ */
 .feature-card-minw {
     min-width: 180px;
-} /* iPhone SEでも2枚目が見切れてスワイプ誘発 */
+} /* iPhone SE でも 2枚目が見切れずスワイプを誘発 */
 @media (min-width: 576px) {
     .feature-card-minw {
         min-width: 220px;
+    }
+}
+
+/* ============================================================================
+  Category buttons row
+============================================================================ */
+.category-row {
+    display: flex;
+    gap: var(--space-1);
+}
+.category-btn {
+    flex: 1 1 18%;
+    max-width: 20%;
+    min-width: 18%;
+    font-size: 12px;
+    padding: 6px 4px;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+@media (max-width: 768px) {
+    .pair-info {
+        font-size: 12px;
+        white-space: nowrap;
+    }
+}
+
+/* ============================================================================
+  Floating Action Button / Bottom Sheet
+============================================================================ */
+.hc-fab {
+    position: fixed;
+    right: 16px;
+    bottom: 88px;
+    z-index: 1050;
+    width: 56px;
+    height: 56px;
+    border-radius: var(--radius-full);
+    display: grid;
+    place-items: center;
+    box-shadow: var(--shadow);
+}
+
+.hc-bottom-sheet {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1040;
+    background: #fff;
+    border-top-left-radius: 16px;
+    border-top-right-radius: 16px;
+    box-shadow: 0 -10px 24px rgba(0, 0, 0, 0.12);
+    padding: 12px 16px 24px;
+}
+.hc-bottom-sheet .hc-handle {
+    width: 40px;
+    height: 4px;
+    background: #dee2e6;
+    border-radius: var(--radius-full);
+    margin: 6px auto 12px;
+}
+.hc-bottom-sheet .hc-date {
+    font-weight: 700;
+}
+.hc-empty {
+    color: var(--ink-muted);
+}
+
+/* ============================================================================
+  FullCalendar – 共通見た目
+============================================================================ */
+.fc .fc-toolbar-title {
+    font-weight: 700;
+}
+.fc .fc-daygrid-day-number {
+    font-weight: 600;
+}
+
+/* 予定ありドット（必要時にセルへ .hc-has-dot を付与） */
+.hc-has-dot {
+    position: relative;
+}
+.hc-has-dot::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 6px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--brand-green);
+}
+
+/* 月表示のピル（時間＋タイトル） */
+.fc .fc-daygrid-event {
+    border: 0;
+    padding: 0;
+}
+.fc .fc-daygrid-event .hc-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.18rem 0.5rem;
+    border-radius: var(--radius-full);
+    background: var(--chip-bg);
+    color: var(--brand-green-ink);
+    font-weight: 600;
+    font-size: 0.85rem;
+    white-space: nowrap; /* 1行で収める */
+}
+.fc .fc-daygrid-event .hc-time {
+    font-variant-numeric: tabular-nums;
+}
+.fc .fc-more-link {
+    font-weight: 700;
+}
+
+/* 週ビュー（timeGrid）の可読性 */
+.fc-timegrid-event .fc-event-main {
+    font-weight: 600;
+    line-height: 1.25;
+}
+
+/* ポップオーバー幅（more の展開） */
+.fc-popover {
+    min-width: 260px;
+}
+
+/* モバイル最適化（SE 幅〜） */
+@media (max-width: 575.98px) {
+    .fc .fc-daygrid-day-frame {
+        padding: 2px 4px;
+    }
+    .fc .fc-daygrid-day-events {
+        margin-top: 2px;
+    }
+    .fc .fc-daygrid-event .hc-pill {
+        font-size: 0.8rem;
+        padding: 0.14rem 0.45rem;
+    }
+    .fc .fc-toolbar-title {
+        font-size: 1.1rem;
     }
 }

--- a/src/public/js/calendar.js
+++ b/src/public/js/calendar.js
@@ -1,0 +1,75 @@
+// public/js/calendar.js
+document.addEventListener("DOMContentLoaded", function () {
+    const calendarEl = document.getElementById("calendar");
+    if (!calendarEl || typeof FullCalendar === "undefined") return;
+
+    const indexUrl =
+        document.querySelector('meta[name="calendar-index-url"]')?.content ||
+        window.location.pathname;
+
+    const isMobile = () => window.innerWidth < 576;
+
+    const cal = new FullCalendar.Calendar(calendarEl, {
+        initialView: "dayGridMonth",
+        locale: "ja",
+        headerToolbar: { left: "prev,next today", center: "title", right: "" },
+        height: "auto",
+        aspectRatio: isMobile() ? 0.95 : 1.35,
+        dayHeaderFormat: { weekday: "short" },
+        dayMaxEventRows: isMobile() ? 2 : 3,
+        moreLinkClick: "popover",
+        moreLinkContent: (arg) => `他${arg.num}件`,
+        eventTimeFormat: { hour: "2-digit", minute: "2-digit", hour12: false },
+
+        // Controller から渡されたイベント
+        events: Array.isArray(window.CalendarData?.events)
+            ? window.CalendarData.events
+            : [],
+
+        // 見やすいピル型に（時間 + タイトル）
+        eventContent: function (arg) {
+            const el = document.createElement("span");
+            el.className = "hc-pill";
+            const time = arg.event.allDay
+                ? ""
+                : `<span class="hc-time">${arg.timeText}</span>`;
+            el.innerHTML = `${time}<span class="hc-title">${
+                arg.event.title || ""
+            }</span>`;
+            return { domNodes: [el] };
+        },
+
+        // description を title 属性に
+        eventDidMount: function (info) {
+            const desc = (
+                info.event.extendedProps.description || ""
+            ).toString();
+            if (desc) info.el.setAttribute("title", desc);
+        },
+
+        // 日付クリック → ?date=YYYY-MM-DD（Bladeで描画させる）
+        dateClick: function (info) {
+            const url = new URL(indexUrl, window.location.origin);
+            url.searchParams.set("date", info.dateStr);
+            window.location.href = url.toString();
+        },
+
+        // イベントクリック → 編集画面へ
+        eventClick: function (info) {
+            info.jsEvent.preventDefault();
+            window.location.href = `/calendar/${info.event.id}/edit`;
+        },
+    });
+
+    cal.render();
+
+    // 画面リサイズ時にモバイル最適値を反映
+    let rid = null;
+    window.addEventListener("resize", () => {
+        clearTimeout(rid);
+        rid = setTimeout(() => {
+            cal.setOption("aspectRatio", isMobile() ? 0.95 : 1.35);
+            cal.setOption("dayMaxEventRows", isMobile() ? 2 : 3);
+        }, 150);
+    });
+});

--- a/src/resources/views/calendar/edit.blade.php
+++ b/src/resources/views/calendar/edit.blade.php
@@ -22,7 +22,7 @@
 
             <div class="mb-3">
                 <label for="event_time" class="form-label">時間</label>
-                <input type="time" name="event_time" id="event_time" class="form-control" value="{{ old('event_time', optional($event->event_time)->format('H:i')) }}">
+                <input type="time" name="event_time" id="event_time" class="form-control" value="{{ old('event_time', $event->event_time ? \Carbon\Carbon::parse($event->event_time)->format('H:i') : '') }}">
             </div>
 
             <div class="mb-3">

--- a/src/resources/views/calendar/index.blade.php
+++ b/src/resources/views/calendar/index.blade.php
@@ -1,173 +1,180 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container mb-4">
-        <h2 class="my-3">カレンダー</h2>
-    <!-- カレンダー表示 -->
-    <div id="calendar" style="min-height: 600px;" class="mb-4"></div>
-    @include('partials.alerts')
+@php
+  $dow = ['日','月','火','水','木','金','土'];
+@endphp
 
-    <!-- 予定追加フォーム -->
-    <div class="card p-3 mb-4">
-        <form action="{{ route('calendar.store') }}" method="POST" class="row g-2 align-items-end">
-            @csrf
-            <div class="col-12 col-md-3">
-                <input type="text" name="title" class="form-control" placeholder="予定のタイトル" required>
-            </div>
-            <div class="col-6 col-md-2">
-                <input type="date" name="event_date" class="form-control" required>
-            </div>
-            <div class="col-6 col-md-2">
-                <input type="time" name="event_time" class="form-control">
-            </div>
-            <div class="col-12 col-md-3">
-                <textarea name="description" class="form-control" rows="1" placeholder="メモ（任意）">{{ old('description') }}</textarea>
-            </div>
-            <div class="col-12 col-md-2 d-grid">
-                <button type="submit" class="btn btn-primary">追加</button>
-            </div>
-        </form>
+<meta name="calendar-index-url" content="{{ route('calendar.index') }}">
+
+<style>
+  /* FullCalendar 内の表示を少し見やすく（任意） */
+  .fc .hc-pill{display:inline-flex;align-items:center;gap:.25rem;padding:0 .375rem;border-radius:9999px;background:#eef4ff;}
+  .fc .hc-time{font-size:.75rem;opacity:.85;}
+  .fc .hc-title{font-size:.75rem;}
+
+  /* ✕ボタン：灰色・中央配置・ホバー可 */
+  .hc-xbtn{
+    width:28px;height:28px;display:inline-flex;align-items:center;justify-content:center;
+    border:1px solid #c8cfd6;border-radius:.5rem;background:#fff;color:#6c757d;
+    padding:0;line-height:1;cursor:pointer;position:relative;z-index:3; /* ← 重要 */
+  }
+  .hc-xbtn:hover{background:#f1f3f5;color:#495057;border-color:#b8c0c8;}
+
+  /* カード全体クリックで編集へ（JS不要・inline onclick） */
+  .event-card{position:relative;cursor:pointer;}
+</style>
+
+<div class="container mb-4" style="max-width:980px;">
+  <div class="d-flex align-items-center justify-content-between mt-3 mb-2">
+    <h2 class="my-0">カレンダー</h2>
+  </div>
+
+  {{-- FullCalendar --}}
+  <div id="calendar" class="mb-4" style="min-height:560px;"></div>
+
+  {{-- 右下の＋（data属性でモーダル起動） --}}
+  <button id="fab-add" class="btn btn-primary hc-fab" aria-label="予定を追加"
+          data-bs-toggle="modal" data-bs-target="#eventModal">
+    <i class="bi bi-plus-lg fs-4"></i>
+  </button>
+
+  {{-- 予定追加モーダル --}}
+  <div class="modal fade" id="eventModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <form id="eventForm" class="modal-content" method="POST" action="{{ route('calendar.store') }}">
+        @csrf
+        <div class="modal-header">
+          <h5 class="modal-title">予定を追加</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+        </div>
+        <div class="modal-body row g-3">
+          <div class="col-12">
+            <label class="form-label">タイトル</label>
+            <input name="title" class="form-control" placeholder="例：保育園送り" required value="{{ old('title') }}">
+          </div>
+          <div class="col-6">
+            <label class="form-label">日付</label>
+            <input id="modal-date" type="date" name="event_date" class="form-control" required
+                   value="{{ old('event_date', $selected ?? now()->format('Y-m-d')) }}">
+          </div>
+          <div class="col-6">
+            <label class="form-label">時間</label>
+            <input type="time" name="event_time" class="form-control" value="{{ old('event_time') }}">
+          </div>
+          <div class="col-12">
+            <label class="form-label">メモ（任意）</label>
+            <textarea name="description" class="form-control" rows="2" placeholder="補足や場所など">{{ old('description') }}</textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary w-100" type="submit">追加</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  {{-- 予定リスト --}}
+  <h3 class="mt-4">予定リスト</h3>
+  <ul class="nav nav-tabs mb-2">
+    <li class="nav-item">
+      <button class="nav-link {{ $selected ? '' : 'active' }}" id="tab-month" data-bs-toggle="tab" data-bs-target="#pane-month" type="button">
+        今月の予定
+        <span id="month-count" class="badge bg-secondary ms-1">
+          {{ $eventsByDate->flatten(1)->count() }}
+        </span>
+      </button>
+    </li>
+    <li class="nav-item">
+      <button class="nav-link {{ $selected ? 'active' : '' }}" id="tab-day" data-bs-toggle="tab" data-bs-target="#pane-day" type="button">
+        選択日の予定
+        @if($selected)
+          @php $d=\Carbon\Carbon::parse($selected); @endphp
+          <span id="day-label" class="text-muted small ms-1">
+            {{ $d->format('n/j') }}（{{ $dow[$d->dayOfWeek] }}）
+          </span>
+        @else
+          <span id="day-label" class="text-muted small ms-1"></span>
+        @endif
+      </button>
+    </li>
+  </ul>
+
+  <div class="tab-content">
+    {{-- 今月の予定 --}}
+    <div class="tab-pane fade {{ $selected ? '' : 'show active' }}" id="pane-month">
+      <div id="month-list">
+        @if($eventsByDate->isEmpty())
+          <div class="text-muted">この月の予定はありません。</div>
+        @else
+          @foreach($eventsByDate->keys()->sort() as $date)
+            @php $d=\Carbon\Carbon::parse($date); @endphp
+            <h6 class="mt-3 mb-2">{{ $d->format('n月j日') }}（{{ $dow[$d->dayOfWeek] }}）</h6>
+
+            @foreach($eventsByDate[$date]->sortBy([['event_time','asc']]) as $ev)
+              @php $time = $ev->event_time_hi; @endphp
+              <div class="card mb-2 shadow-sm event-card"
+                   role="button"
+                   onclick="if(!event.target.closest('form') && !event.target.closest('button')){ window.location.href='{{ route('calendar.edit', $ev->id) }}'; }">
+                <div class="card-body py-2 d-flex justify-content-between align-items-start">
+                  <div class="pe-2">
+                    <div class="fw-semibold">{{ $ev->title }}</div>
+                    <div class="text-muted small mt-1">{{ $time ?? '--:--' }}　{{ $ev->description }}</div>
+                  </div>
+                  <form method="POST" action="{{ route('calendar.destroy', $ev->id) }}"
+                        onsubmit="event.stopPropagation(); return confirm('この予定を削除しますか？');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="hc-xbtn" aria-label="削除" title="削除"
+                            onclick="event.stopPropagation();">×</button>
+                  </form>
+                </div>
+              </div>
+            @endforeach
+          @endforeach
+        @endif
+      </div>
     </div>
 
-    <!-- 予定リスト -->
-    <h3 class="mt-4">予定リスト</h3>
-    <div id="event-list-area"></div>
+    {{-- 選択日の予定 --}}
+    <div class="tab-pane fade {{ $selected ? 'show active' : '' }}" id="pane-day">
+      <div id="day-list">
+        @if(!$selected)
+          <div class="text-muted">日付をクリックすると、この日の予定が表示されます。</div>
+        @elseif($dayEvents->isEmpty())
+          <div class="text-muted">この日の予定はありません。</div>
+        @else
+          @foreach($dayEvents as $ev)
+            @php $time = $ev->event_time_hi; @endphp
+            <div class="card mb-2 shadow-sm event-card"
+                 role="button"
+                 onclick="if(!event.target.closest('form') && !event.target.closest('button')){ window.location.href='{{ route('calendar.edit', $ev->id) }}'; }">
+              <div class="card-body py-2 d-flex justify-content-between align-items-start">
+                <div class="pe-2">
+                  <div class="fw-semibold">{{ $ev->title }}</div>
+                  <div class="text-muted small mt-1">{{ $time ?? '--:--' }}　{{ $ev->description }}</div>
+                </div>
+                <form method="POST" action="{{ route('calendar.destroy', $ev->id) }}"
+                      onsubmit="event.stopPropagation(); return confirm('この予定を削除しますか？');">
+                  @csrf
+                  @method('DELETE')
+                  <button type="submit" class="hc-xbtn" aria-label="削除" title="削除"
+                          onclick="event.stopPropagation();">×</button>
+                </form>
+              </div>
+            </div>
+          @endforeach
+        @endif
+      </div>
+    </div>
+  </div>
 </div>
-<div class="d-flex justify-content-center mt-4">
-        <a href="{{ route('pair.show') }}" class="btn btn-secondary mb-3">ペアページへ</a>
-</div>
 
-<!-- FullCalendar CSS・JS -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.css">
-<script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js"></script>
-
-<!-- LaravelイベントデータをJSに渡す -->
+{{-- FullCalendar に渡すデータ --}}
 <script>
-    const allEvents = @json($events);
+  window.CalendarData = {
+    events: @json($fcEvents),
+  };
 </script>
-
-<script>
-    function isMobile() {
-        return window.innerWidth < 768;
-    }
-
-    function renderEventList(events, currentMonth) {
-        const listArea = document.getElementById('event-list-area');
-        listArea.innerHTML = '';
-
-        const filtered = events.filter(e => {
-            const date = new Date(e.event_date);
-            return date.getFullYear() === currentMonth.getFullYear() &&
-                date.getMonth() === currentMonth.getMonth();
-        });
-
-        if (filtered.length === 0) {
-            listArea.innerHTML = '<p>予定はありません。</p>';
-            return;
-        }
-
-        if (isMobile()) {
-            // スマホ表示（カード）
-            filtered.forEach(event => {
-                const dateObj = new Date(event.event_date);
-                const formattedDate = `${dateObj.getMonth() + 1}/${dateObj.getDate()}`;
-
-                const timeObj = event.event_time ? new Date(`1970-01-01T${event.event_time}`) : null;
-                const formattedTime = timeObj
-                    ? `${timeObj.getHours().toString().padStart(2, '0')}:${timeObj.getMinutes().toString().padStart(2, '0')}`
-                    : '--:--';
-
-                const html = `
-                    <div class="border border-warning rounded bg-warning-subtle p-2 mb-2">
-                        <div class="fw-bold">${event.title}</div>
-                        <small class="text-muted">日付：${formattedDate}</small><br>
-                        <small class="text-muted">時間：${formattedTime}</small><br>
-                        <small class="text-muted">メモ：${event.description ? `${event.description}` : ''}</small><br>
-                        <div class="mt-2 d-flex gap-2">
-                            <a href="/calendar/${event.id}/edit" class="btn btn-sm btn-warning">編集</a>
-                            <form method="POST" action="/calendar/${event.id}" class="d-inline">
-                                <input type="hidden" name="_method" value="DELETE">
-                                <input type="hidden" name="_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="btn btn-sm btn-danger">削除</button>
-                            </form>
-                        </div>
-                    </div>
-                `;
-                listArea.insertAdjacentHTML('beforeend', html);
-            });
-        } else {
-            // PC表示（表形式）
-            let html = `
-                <div class="table-responsive">
-                <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th>タイトル</th>
-                            <th>日付</th>
-                            <th>時間</th>
-                            <th>メモ</th>
-                            <th>操作</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-            `;
-
-            filtered.forEach(event => {
-                const dateObj = new Date(event.event_date);
-                const formattedDate = `${dateObj.getMonth() + 1}/${dateObj.getDate()}`;
-
-                const timeObj = event.event_time ? new Date(`1970-01-01T${event.event_time}`) : null;
-                const formattedTime = timeObj
-                    ? `${timeObj.getHours().toString().padStart(2, '0')}:${timeObj.getMinutes().toString().padStart(2, '0')}`
-                    : '--:--';
-
-                html += `
-                    <tr>
-                        <td>${event.title}</td>
-                        <td>${formattedDate}</td>
-                        <td>${formattedTime}</td>
-                        <td>${event.description ?? ''}</td>
-                        <td>
-                            <a href="/calendar/${event.id}/edit" class="btn btn-sm btn-warning">編集</a>
-                            <form method="POST" action="/calendar/${event.id}" style="display:inline;">
-                                <input type="hidden" name="_method" value="DELETE">
-                                <input type="hidden" name="_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="btn btn-sm btn-danger">削除</button>
-                            </form>
-                        </td>
-                    </tr>
-                `;
-            });
-
-            html += `</tbody></table></div>`;
-            listArea.innerHTML = html;
-        }
-    }
-
-    document.addEventListener('DOMContentLoaded', function () {
-        const calendarEl = document.getElementById('calendar');
-        const calendar = new FullCalendar.Calendar(calendarEl, {
-            initialView: 'dayGridMonth',
-            locale: 'ja',
-            headerToolbar: {
-                left: 'prev,next today',
-                center: 'title',
-                right: ''
-            },
-            events: allEvents.map(e => ({
-                title: e.title,
-                start: e.event_date,
-                color: '#28a745'
-            })),
-            displayEventTime: false,
-            eventDisplay: 'block',
-            datesSet: function(info) {
-                const currentDate = calendar.getDate(); // ← ここで正確な表示月取得
-                renderEventList(allEvents, currentDate);
-            }
-        });
-        calendar.render();
-        renderEventList(allEvents, calendar.getDate()); // 初期表示
-    });
-</script>
+<script src="{{ asset('js/calendar.js') }}"></script>
 @endsection


### PR DESCRIPTION
## 概要
- 予定リストは **Blade主導**で描画し、JSはFullCalendar起動＋遷移のみの最小構成へ。
- **FullCalendarに予定が出ない**問題を修正（startを必ず `YYYY-MM-DD` / `YYYY-MM-DDTHH:MM` に統一）。
- 予定カードの右側に **灰色の×** ボタンを配置。ホバー有効、**カードクリックの編集遷移とは独立**（クリック伝播を停止）。
- 時刻はアプリ内で **常に「HH:MM」** 表示に統一（Modelアクセサ）。
- `pair_id` は **null運用**。store/updateで空文字混入を避けるために明示的に `null` を設定。

## 変更内容
### コード
- `app/Http/Controllers/CalendarController.php`
  - FullCalendar用データの `start` を `toDateString()` + `T` + `H:i` で構築。
  - store/updateで `pair_id = null` を明示。
  - 予定リスト/選択日データをサーバー側で用意（Blade描画用）。
- `app/Models/Calendar.php`
  - `getEventTimeHiAttribute()` を追加し、**秒切り** & 例外耐性で常に `H:i` を返す。
- `resources/views/calendar/index.blade.php`
  - リストは **Bladeでループ描画**。
  - カード全体クリックで編集遷移（inline onclick）。×はフォーム送信（CSRF/DELETE）。
  - `.hc-xbtn`（灰色の×）スタイル追加、`z-index` 付与、`stopPropagation()` で編集遷移を抑止。
- `public/js/calendar.js`
  - FullCalendarの初期化のみ。日付クリック→ `?date=YYYY-MM-DD` 遷移、イベントクリック→編集。
  - モバイルでの `aspectRatio` や `dayMaxEventRows` を調整。イベントはピル表示。

### UI/UX
- カレンダー：イベントは**淡いピル**で時間+タイトル表示、モバイルでも崩れにくい。
- 予定リスト：**カード全体＝編集** / **×＝削除** を明確に分離。
- FAB（＋）：data属性でモーダル起動（JS不要）。

## 動作確認
1. `/calendar` を開く → FullCalendarにイベントが表示される。
2. 任意の日付をクリック → `?date=YYYY-MM-DD` へ遷移し、「選択日の予定」タブに当日分が表示。
3. 予定カード本体をクリック → `/calendar/{id}/edit` へ遷移。
4. 予定カード右の **×** をクリック → 確認→削除。編集画面には遷移しない。
5. ＋ボタン→モーダルから新規登録 → リスト/カレンダー双方に反映。
6. 時刻はいつでも `HH:MM` 表示。

## スキーマ/移行
- 運用は `pair_id` を **nullable** としており、DB側はphpMyAdminで変更済み。
- リポジトリ整合性のために**別PRでマイグレーション追加**を推奨（必要なら案も用意します）。

## 影響範囲・リスク
- Calendar周りのBlade/Controller/JSに限定。既存の通知処理は維持。
- 旧 `pair_id` 依存がないかは一通りgrep済みを推奨（`pair_id` を完全撤去する場合は別PRで）。

## スクリーンショット
（※レビュアー向け：このPRの説明用に、SP/PCのBefore/Afterをコメントで貼ります）

## チェックリスト
- [ ] FullCalendarに予定が表示される
- [ ] ×ボタンで削除できる（ホバー効く/編集に遷移しない）
- [ ] 新規追加→リスト/カレンダーに反映
- [ ] 時刻は `HH:MM` 表示
- [ ] エラー時、flashメッセージが出る
'